### PR TITLE
Document usage of public calendar

### DIFF
--- a/how-to/access-isc-calendar.md
+++ b/how-to/access-isc-calendar.md
@@ -1,5 +1,5 @@
-The InnerSource Commons Foundation has a Google calendar that members can use to schedule events in the InnerSource Commons.
-If you want to use the calendar, then you can request access from [@Lenucksi] for your Google account.
+The InnerSource Commons Foundation has a [public Google calendar](https://calendar.google.com/calendar/embed?src=c_62694f414055ac569e5cb12dafbb0890ca22f3640b177a4b10b53171fbc9bdd4%40group.calendar.google.com&ctz=America%2FChicago) that people can use to schedule events in the InnerSource Commons.
+If you want to use the calendar, then you can request access from [@russ] for your Google account.
 After you have access, the InnerSource Commons Calendar should show up in your list of available calendars in the Google Calendar UI.
 
-[@Lenucksi]: https://app.slack.com/client/T04PXKRM0/DFJ4THQFQ
+[@russ]: https://app.slack.com/client/T04PXKRM0/D4RBDR7FB


### PR DESCRIPTION
Read [the documentation](https://github.com/InnerSourceCommons/foundation-governance/blob/rrrutledge-patch-1/how-to/access-isc-calendar.md).