### PR TITLE
docs: expand on public calendar access

### DIFF
--- a/how-to/access-isc-calendar.md
+++ b/how-to/access-isc-calendar.md
@@ -17,7 +17,7 @@ URL for the private calendar: https://calendar.google.com/calendar/ical/c_d2d0ea
 # Introduction to adding calendar events to our public calendar
 
 The InnerSource Commons Foundation has a public [Google calendar] that people can use to view and schedule events in the InnerSource Commons [website](https://innersourcecommons.org/calendar/).
-If you want to add an InnerSource event to our public calendar, you can request access by posting a message in the [#google-admins] Slack channel.
+If you want to add an InnerSource event to our public calendar, you can request access by posting a message in the [#google-admins] Slack channel. (if you have an @innersourcecommons.org address you should have access by default)
 
 The InnerSource Commons Public Calendar is for public events.
 The InnerSource Commons Private Calendar is for private events and should only be used by Foundation members.


### PR DESCRIPTION
I fixed the access so anyone with an innersource address will have access to the public one