### PR TITLE
Add shared drive structure definition

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @InnerSourceCommons/isc-board

--- a/.github/workflows/root-structure.yml
+++ b/.github/workflows/root-structure.yml
@@ -1,0 +1,26 @@
+name: Compile Root Structure JSONC to JSON
+
+on:
+  push:
+    paths:
+      - '**/*.jsonc'
+
+jobs:
+  compile:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Convert JSONC to JSON
+        run: |
+          find shared-drive-structure -name "*.jsonc" -not -path "./.git/*" | while read f; do
+            out="${f%.jsonc}.json"
+            npx --yes strip-json-comments-cli "$f" > "$out"
+            echo "Converted $f → $out"
+          done
+
+      - uses: stefanzweifel/git-auto-commit-action@v5
+        if: ${{ env.ACT != 'true' }}
+        with:
+          commit_message: "chore: compile JSONC → JSON"
+          file_pattern: "**/*.json"

--- a/shared-drive-structure/README.md
+++ b/shared-drive-structure/README.md
@@ -1,0 +1,7 @@
+# Shared Drive structure (reference)
+
+This folder holds a **machine-readable snapshot** of the InnerSource Commons **Google Shared Drive** root layout: [`root-structure.jsonc`](root-structure.jsonc).
+
+The `.jsonc` file is ordinary JSON plus `//` comments. Those comments carry the human-readable intent from the governance write-up (folders, files, workflow, and access notes). Pipelines that need strict JSON can strip comments or generate JSON from this file.
+
+**Automation:** The [InnerSourceCommons/n8n](https://github.com/InnerSourceCommons/n8n) repo consumes this structure so workflows can **create or check Drive layout** against the agreed tree. If you change folder names or nesting here, update n8n (or any other consumer) so it stays aligned with Drive.

--- a/shared-drive-structure/root-structure.jsonc
+++ b/shared-drive-structure/root-structure.jsonc
@@ -1,0 +1,109 @@
+// InnerSource Commons — Shared Drive root layout (machine-readable)
+//
+// Source: governance doc "Root Structure (Shared Drive)" — canonical description of the
+// desired Google Shared Drive layout: simplify artifacts, standardize collaboration, and
+// align Drive folders with GitHub publication. Some WG content may stay private (e.g. GDPR).
+//
+// Consumption: automation (e.g. n8n in https://github.com/InnerSourceCommons/n8n) should
+// treat this tree as the compliance target when creating or validating folders in Drive.
+// Keep `name` / `children` shape stable for those workflows.
+//
+// Naming (from governance): "<YYYY-MM-DD> – <WG Name> – <Document Title>" for sortable titles.
+// GitHub is the stable public source of truth; Drive is the collaboration incubator.
+//
+[
+  // 00 – Governance — "Handles rules and people." Constitution: how people collaborate,
+  // who owns what, and how content is managed.
+  {
+    "name": "00 – Governance",
+    "children": [
+      { "name": "Charter.gdoc" },
+      { "name": "Roles & Responsibilities.gdoc" },
+      { "name": "Style Guide (Docs).gdoc" },
+      // Process doc: Google → GitHub handoff (draft, pre-publish, migration, archive).
+      { "name": "Workflow: Google -> GitHub" },
+      { "name": "Naming Conventions.gdoc" },
+      { "name": "Permissions Model.gdoc" }
+    ]
+  },
+
+  // 01 – Working Groups — Each WG gets a subfolder with clear ownership; same pattern as
+  // governed areas elsewhere. Stable collaboration space so WG work does not mix with
+  // other areas. Replace <WG Name> with the actual working group name.
+  {
+    "name": "01 – Working Groups",
+    "children": [
+      { "name": "Charter.gdoc" },
+      { "name": "<WG Name> – Documentation" },
+      { "name": "<WG Name> – Meetings" }
+    ]
+  },
+
+  // 02 – Drafts & Work-in-Progress — Work in development: articles, patterns, case studies,
+  // training, blog posts. "Ready for Publication to GitHub" is the staging area before
+  // maintainers convert to Markdown and open PRs.
+  {
+    "name": "02 – Drafts & Work-in-Progress",
+    "children": [
+      { "name": "Articles" },
+      { "name": "Patterns" },
+      { "name": "Case Studies" },
+      { "name": "Training" },
+      { "name": "Blog Posts" },
+      { "name": "Ready for Publication to GitHub" }
+    ]
+  },
+
+  // 03 – Published (To Github) — Source of truth in Drive for content that is GitHub-ready
+  // (published or aligned with the public repo).
+  {
+    "name": "03 – Published (To Github)"
+  },
+
+  // 04 – Assets — Shared media: images, decks; brand and diagram assets live under Brand & Visuals.
+  {
+    "name": "04 – Assets",
+    "children": [
+      {
+        "name": "Brand & Visuals",
+        "children": [
+          { "name": "Logo Variants" },
+          { "name": "Color Guides" },
+          { "name": "Diagrams" }
+        ]
+      }
+    ]
+  },
+
+  // 05 – Templates — Reusable starting points (e.g. Google Doc templates).
+  {
+    "name": "05 – Templates",
+    "children": [
+      { "name": "Case Study Template.gdoc" },
+      { "name": "Working Group Charter Template.gdoc" }
+    ]
+  },
+
+  // 06 – Community & Meetings — Community-facing material such as meeting notes.
+  {
+    "name": "06 – Community & Meetings"
+  },
+
+  // 07 – Outreach & Education — Outreach content: case studies, training, certifications, etc.
+  {
+    "name": "07 – Outreach & Education"
+  },
+
+  // 08 – Credentials — Accounts and secrets (Zoom, Google Workspace, …). Add subfolders as
+  // needed; restrict access to least privilege.
+  {
+    "name": "08 – Credentials"
+  },
+
+  // 09 – Archives — Deprecated or superseded material; year buckets (e.g. 2026, 2027) for
+  // post-publication Drive copies per governance workflow.
+  {
+    "name": "09 – Archives",
+    "children": [{ "name": "2026" }, { "name": "2027" }]
+  }
+]


### PR DESCRIPTION
## Summary
- Adds a machine-readable JSONC file (`shared-drive-structure/root-structure.jsonc`) defining the InnerSource Commons Google Shared Drive root layout
- Includes a README explaining the file's purpose and its relationship to the n8n automation repo
- Adds a GitHub Actions workflow to compile the JSONC to strict JSON on push

## Test plan
- [ ] Verify the JSONC file parses correctly (valid JSON with comments)
- [ ] Confirm the GitHub Actions workflow triggers on `.jsonc` file changes
- [ ] Check that the generated JSON output matches the expected structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)